### PR TITLE
Fix for nested templates folders e.g. www/templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ class EjsPlugin {
   }
 
   _basePath(filePath) {
-    var parts = filePath.split(path.sep);
-    var baseDir = this.config.watched.find(d => parts.indexOf(d) > -1);
+    var baseDir;
+    this.config.watched.forEach( (d) => {
+      if (filePath.indexOf(d) == 0) {
+        baseDir = filePath.replace(d, "");
+      }
+    });
     var relPath = path.relative(baseDir, filePath);
     return relPath && `${path.dirname(relPath)}/`;
   }


### PR DESCRIPTION
Currently if templates folder is not located in the root of the project an error happens. 

var baseDir = this.config.watched.find(d => parts.indexOf(d) > -1);

// this.config.watched = ['www/templates', ...]
// parts = ['www', 'templates', 'path', 'to', 'template'] 

I did a fix that compares whole string filePath with   this.config.watched. Works fine for me. Unfortunately don't have too much tests for that. 
