### PR TITLE
use old style function() syntax, to fix bug with minification for prod build

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ class EjsPlugin {
       // Return a callable function which will execute the function
       // created by the source-code, with the passed data as locals
       // Add a local `include` function which uses require to load files
-      var returnedFn = data => {
-        var include = (includePath, includeData) => {
+      var returnedFn = function(data) {
+        var include = function(includePath, includeData) {
           var _fn = require(basePath + includePath);
           return _fn(includeData);
         };


### PR DESCRIPTION
I found another issue when building with -p flag. Looks like the problem in order of operations. So when I ran brunch build -p I got an issue with minification 

24 Nov 18:28:17 - error: JS minification failed on www/dist/js/app.js: SyntaxError: Unexpected token: operator (>) (line: 14480, col: 21, pos: 646029)

I checked it out app.js and found out that is contain non-converted ES2015 javascript. I made a hotfix with updating to old syntax and it works fine now. 